### PR TITLE
Use the `registry` image synced by the image-syncer

### DIFF
--- a/config/docker-registry/charts/docker-registry/templates/deployment.yaml
+++ b/config/docker-registry/charts/docker-registry/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
       hostIPC: false # Optional. The default is false if the entry is not there.
       initContainers:
         - name: generate-htpasswd
-          image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.registry-init) }}"
+          image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.registry_init) }}"
 {{- if .Values.initContainers.securityContext }}
           securityContext:
             {{- include "tplValue" ( dict "value" .Values.initContainers.securityContext "context" . ) | nindent 12 }}

--- a/config/docker-registry/charts/docker-registry/templates/deployment.yaml
+++ b/config/docker-registry/charts/docker-registry/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
       hostIPC: false # Optional. The default is false if the entry is not there.
       initContainers:
         - name: generate-htpasswd
-          image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.registry) }}"
+          image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.registry-init) }}"
 {{- if .Values.initContainers.securityContext }}
           securityContext:
             {{- include "tplValue" ( dict "value" .Values.initContainers.securityContext "context" . ) | nindent 12 }}

--- a/config/docker-registry/values.yaml
+++ b/config/docker-registry/values.yaml
@@ -10,8 +10,12 @@ global:
     path: europe-docker.pkg.dev/kyma-project
   images:
     registry:
-      name: "tpi/registry"
-      version: "2.8.1-1ae4c190"
+      name: "registry"
+      version: "2.8.3"
+      directory: "prod/external"
+    registry-init:
+      name: "registry-init"
+      version: "v20240506-57d31b1d"
       directory: "prod"
   dockerregistryPriorityClassValue: 2000000
   dockerregistryPriorityClassName: "dockerregistry-priority"

--- a/config/docker-registry/values.yaml
+++ b/config/docker-registry/values.yaml
@@ -13,7 +13,7 @@ global:
       name: "registry"
       version: "2.8.3"
       directory: "prod/external"
-    registry-init:
+    registry_init:
       name: "registry-init"
       version: "v20240506-57d31b1d"
       directory: "prod"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -2,7 +2,8 @@ module-name: docker-registry
 rc-tag: 1.4.0
 protecode:
   - europe-docker.pkg.dev/kyma-project/prod/dockerregistry-operator:main
-  - europe-docker.pkg.dev/kyma-project/prod/tpi/registry:2.8.1-1ae4c190
+  - europe-docker.pkg.dev/kyma-project/prod/external/registry:2.8.3
+  - europe-docker.pkg.dev/kyma-project/prod/registry-init:v20240506-57d31b1d
 whitesource:
   language: golang-mod
   subprojects: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- use `external/registry` instead of `tpi/registry` image
- define usage of the `registry-init` image

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/docker-registry/issues/18