### PR TITLE
Turn off update-integration GA job because of absence of release

### DIFF
--- a/.github/workflows/operator-verify.yaml
+++ b/.github/workflows/operator-verify.yaml
@@ -69,36 +69,36 @@ jobs:
         if: ${{ always() }}
         run: make -C tests/operator cluster-info
 
-
-  operator-upgrade-test:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.SETUP_GO_VERSION }}
-      - name: create single cluster
-        uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 #v2.4.0
-        with:
-          cluster-name: "k3dCluster"
-          args: >-
-            --agents 1
-            --image rancher/k3s:v1.29.3-k3s1
-            --port 80:80@loadbalancer
-            --port 443:443@loadbalancer
-            --wait
-      - name: upgrade test
-        run: |
-          make -C components/operator deploy-release
-          make -C tests/operator test
-          make -C components/operator deploy
-          make -C tests/operator test
-        env:
-          IMG: europe-docker.pkg.dev/kyma-project/prod/dockerregistry-operator:${{ github.sha }}
-      - name: collect cluster-info
-        if: ${{ always() }}
-        run: make -C tests/operator cluster-info
+#TODO: after the first release bring this test back with deploy-release target
+#  operator-upgrade-test:
+#    runs-on: ubuntu-latest
+#    if: github.event_name == 'push'
+#    steps:
+#      - uses: actions/checkout@v4
+#      - uses: actions/setup-go@v5
+#        with:
+#          go-version: ${{ env.SETUP_GO_VERSION }}
+#      - name: create single cluster
+#        uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 #v2.4.0
+#        with:
+#          cluster-name: "k3dCluster"
+#          args: >-
+#            --agents 1
+#            --image rancher/k3s:v1.29.3-k3s1
+#            --port 80:80@loadbalancer
+#            --port 443:443@loadbalancer
+#            --wait
+#      - name: upgrade test
+#        run: |
+#          make -C components/operator deploy-release
+#          make -C tests/operator test
+#          make -C components/operator deploy
+#          make -C tests/operator test
+#        env:
+#          IMG: europe-docker.pkg.dev/kyma-project/prod/dockerregistry-operator:${{ github.sha }}
+#      - name: collect cluster-info
+#        if: ${{ always() }}
+#        run: make -C tests/operator cluster-info
 
   gardener-integration-test:
     if: github.event_name == 'push'

--- a/components/operator/Makefile
+++ b/components/operator/Makefile
@@ -91,6 +91,11 @@ deploy-main: manifests kustomize ## Deploy controller to the K8s cluster specifi
 generate-kustomization-dev:
 	cp $(CONFIG_OPERATOR_DEV)/kustomization.yaml.tpl $(CONFIG_OPERATOR_DEV)/kustomization.yaml
 
+.PHONY: deploy-release
+deploy-release: ## Deploy operator to the k8s cluster specified in ~/.kube/config with image from latest release.
+	kubectl create namespace kyma-system || true
+	kubectl apply -f https://github.com/kyma-project/docker-registry/releases/latest/download/docker-registry.yaml
+
 .PHONY: deploy
 deploy: manifests kustomize generate-kustomization-dev ## Deploy controller to the K8s cluster specified in ~/.kube/config with image from IMG env.
 	kubectl create namespace kyma-system || true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Turn off temporary update-integration GA job because of absence of release.
Gardener-integration is working now - the configuration is set correctly.