### PR TITLE
Remove unused fields from the CR's types

### DIFF
--- a/components/operator/api/v1alpha1/dockerregistry_types.go
+++ b/components/operator/api/v1alpha1/dockerregistry_types.go
@@ -27,9 +27,7 @@ type Endpoint struct {
 
 // DockerRegistrySpec defines the desired state of DockerRegistry
 type DockerRegistrySpec struct {
-	// Sets the timeout for the Function health check. The default value in seconds is `10`
-	HealthzLivenessTimeout string   `json:"healthzLivenessTimeout,omitempty"` //TODO: probably it was only used by serverless so it could be removed
-	Storage                *Storage `json:"storage,omitempty"`
+	Storage *Storage `json:"storage,omitempty"`
 }
 
 type Storage struct {
@@ -106,8 +104,6 @@ type DockerRegistryStatus struct {
 	SecretName string `json:"secretName,omitempty"`
 
 	Storage string `json:"storage,omitempty"`
-
-	HealthzLivenessTimeout string `json:"healthzLivenessTimeout,omitempty"`
 
 	// State signifies current state of DockerRegistry.
 	// Value can be one of ("Ready", "Processing", "Error", "Deleting").

--- a/components/operator/internal/chart/flags.go
+++ b/components/operator/internal/chart/flags.go
@@ -1,7 +1,6 @@
 package chart
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/kyma-project/docker-registry/components/operator/api/v1alpha1"
@@ -9,7 +8,6 @@ import (
 
 type FlagsBuilder interface {
 	Build() map[string]interface{}
-	WithControllerConfiguration(healthzLivenessTimeout string) *flagsBuilder
 	WithRegistryCredentials(username string, password string) *flagsBuilder
 	WithRegistryHttpSecret(httpSecret string) *flagsBuilder
 	WithNodePort(nodePort int64) *flagsBuilder
@@ -61,24 +59,6 @@ func lastElement(values []string, i int) bool {
 
 func nextDeeperFlag(currentFlag map[string]interface{}, path string) map[string]interface{} {
 	return currentFlag[path].(map[string]interface{})
-}
-
-func (fb *flagsBuilder) WithControllerConfiguration(healthzLivenessTimeout string) *flagsBuilder {
-	optionalFlags := []struct {
-		key   string
-		value string
-	}{
-		{"healthzLivenessTimeout", healthzLivenessTimeout},
-	}
-
-	for _, flag := range optionalFlags {
-		if flag.value != "" {
-			fullPath := fmt.Sprintf("containers.manager.configuration.data.%s", flag.key)
-			fb.flags[fullPath] = flag.value
-		}
-	}
-
-	return fb
 }
 
 func (fb *flagsBuilder) WithRegistryCredentials(username, password string) *flagsBuilder {

--- a/components/operator/internal/chart/flags_test.go
+++ b/components/operator/internal/chart/flags_test.go
@@ -14,15 +14,6 @@ func Test_flagsBuilder_Build(t *testing.T) {
 
 	t.Run("build flags", func(t *testing.T) {
 		expectedFlags := map[string]interface{}{
-			"containers": map[string]interface{}{
-				"manager": map[string]interface{}{
-					"configuration": map[string]interface{}{
-						"data": map[string]interface{}{
-							"healthzLivenessTimeout": "testHealthzLivenessTimeout",
-						},
-					},
-				},
-			},
 			"registryHTTPSecret": "testHttpSecret",
 			"rollme":             "dontrollplease",
 			"dockerRegistry": map[string]interface{}{

--- a/components/operator/internal/chart/flags_test.go
+++ b/components/operator/internal/chart/flags_test.go
@@ -36,9 +36,7 @@ func Test_flagsBuilder_Build(t *testing.T) {
 			WithNodePort(1234).
 			WithRegistryCredentials("testUsername", "testPassword").
 			WithRegistryHttpSecret("testHttpSecret").
-			WithControllerConfiguration(
-				"testHealthzLivenessTimeout",
-			).Build()
+			Build()
 
 		require.Equal(t, expectedFlags, flags)
 	})
@@ -54,27 +52,6 @@ func Test_flagsBuilder_Build(t *testing.T) {
 		flags := NewFlagsBuilder().
 			WithRegistryCredentials("testUsername", "testPassword").
 			Build()
-
-		require.Equal(t, expectedFlags, flags)
-	})
-
-	t.Run("build not empty controller configuration flags only", func(t *testing.T) {
-		expectedFlags := map[string]interface{}{
-			"containers": map[string]interface{}{
-				"manager": map[string]interface{}{
-					"configuration": map[string]interface{}{
-						"data": map[string]interface{}{
-							"healthzLivenessTimeout": "testHealthzLivenessTimeout",
-						},
-					},
-				},
-			},
-		}
-
-		flags := NewFlagsBuilder().
-			WithControllerConfiguration(
-				"testHealthzLivenessTimeout",
-			).Build()
 
 		require.Equal(t, expectedFlags, flags)
 	})

--- a/components/operator/internal/state/controller_configuration.go
+++ b/components/operator/internal/state/controller_configuration.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+
 	"github.com/kyma-project/docker-registry/components/operator/internal/registry"
 
 	"github.com/kyma-project/docker-registry/components/operator/api/v1alpha1"
@@ -19,8 +20,6 @@ func sFnControllerConfiguration(_ context.Context, r *reconciler, s *systemState
 		return stopWithEventualError(err)
 	}
 
-	configureControllerConfigurationFlags(s)
-
 	s.setState(v1alpha1.StateProcessing)
 	s.instance.UpdateConditionTrue(
 		v1alpha1.ConditionTypeConfigured,
@@ -35,7 +34,6 @@ func updateControllerConfigurationStatus(r *reconciler, instance *v1alpha1.Docke
 	spec := instance.Spec
 	storageField := getStorageField(spec.Storage, instance)
 	fields := fieldsToUpdate{
-		{spec.HealthzLivenessTimeout, &instance.Status.HealthzLivenessTimeout, "Duration of health check", ""},
 		{registry.SecretName, &instance.Status.SecretName, "Name of secret with registry access data", ""},
 		storageField,
 	}
@@ -52,11 +50,4 @@ func getStorageField(storage *v1alpha1.Storage, instance *v1alpha1.DockerRegistr
 		}
 	}
 	return fieldToUpdate{storageName, &instance.Status.Storage, "Storage type", ""}
-}
-
-func configureControllerConfigurationFlags(s *systemState) {
-	s.flagsBuilder.
-		WithControllerConfiguration(
-			s.instance.Status.HealthzLivenessTimeout,
-		)
 }

--- a/components/operator/internal/state/controller_configuration_test.go
+++ b/components/operator/internal/state/controller_configuration_test.go
@@ -16,10 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-const (
-	healthzLivenessTimeoutTest = "test-healthz-liveness-timeout"
-)
-
 func Test_sFnControllerConfiguration(t *testing.T) {
 	configurationReadyMsg := "Configuration ready"
 

--- a/components/operator/internal/state/controller_configuration_test.go
+++ b/components/operator/internal/state/controller_configuration_test.go
@@ -46,14 +46,6 @@ func Test_sFnControllerConfiguration(t *testing.T) {
 			v1alpha1.ConditionReasonConfigured,
 			configurationReadyMsg,
 		)
-
-		expectedEvents := []string{
-			"Normal Configuration Duration of health check set from '' to 'test-healthz-liveness-timeout'",
-		}
-
-		for _, expectedEvent := range expectedEvents {
-			require.Equal(t, expectedEvent, <-eventRecorder.Events)
-		}
 	})
 
 	t.Run("update status additional configuration overrides", func(t *testing.T) {
@@ -90,13 +82,6 @@ func Test_sFnControllerConfiguration(t *testing.T) {
 			configurationReadyMsg,
 		)
 
-		expectedEvents := []string{
-			"Normal Configuration Duration of health check set from '' to 'test-healthz-liveness-timeout'",
-		}
-
-		for _, expectedEvent := range expectedEvents {
-			require.Equal(t, expectedEvent, <-eventRecorder.Events)
-		}
 	})
 
 	t.Run("reconcile from configurationError", func(t *testing.T) {

--- a/components/operator/internal/state/controller_configuration_test.go
+++ b/components/operator/internal/state/controller_configuration_test.go
@@ -26,9 +26,7 @@ func Test_sFnControllerConfiguration(t *testing.T) {
 	t.Run("update status additional configuration overrides", func(t *testing.T) {
 		s := &systemState{
 			instance: v1alpha1.DockerRegistry{
-				Spec: v1alpha1.DockerRegistrySpec{
-					HealthzLivenessTimeout: healthzLivenessTimeoutTest,
-				},
+				Spec: v1alpha1.DockerRegistrySpec{},
 			},
 			flagsBuilder: chart.NewFlagsBuilder(),
 		}
@@ -42,7 +40,6 @@ func Test_sFnControllerConfiguration(t *testing.T) {
 		requireEqualFunc(t, sFnApplyResources, next)
 
 		status := s.instance.Status
-		require.Equal(t, healthzLivenessTimeoutTest, status.HealthzLivenessTimeout)
 		require.Equal(t, registry.SecretName, status.SecretName)
 		require.Equal(t, FilesystemStorageName, status.Storage)
 
@@ -67,7 +64,6 @@ func Test_sFnControllerConfiguration(t *testing.T) {
 		s := &systemState{
 			instance: v1alpha1.DockerRegistry{
 				Spec: v1alpha1.DockerRegistrySpec{
-					HealthzLivenessTimeout: healthzLivenessTimeoutTest,
 					Storage: &v1alpha1.Storage{
 						Azure: &v1alpha1.StorageAzure{
 							SecretName: "azureSecret",
@@ -87,7 +83,6 @@ func Test_sFnControllerConfiguration(t *testing.T) {
 		requireEqualFunc(t, sFnApplyResources, next)
 
 		status := s.instance.Status
-		require.Equal(t, healthzLivenessTimeoutTest, status.HealthzLivenessTimeout)
 		require.Equal(t, registry.SecretName, status.SecretName)
 		require.Equal(t, AzureStorageName, status.Storage)
 

--- a/tests/operator/main.go
+++ b/tests/operator/main.go
@@ -45,9 +45,7 @@ func main() {
 		Name:                     "default-test",
 		DockerregistryDeployName: "dockerregistry",
 		RegistryName:             "dockerregistry-docker-registry",
-		UpdateSpec: v1alpha1.DockerRegistrySpec{
-			HealthzLivenessTimeout: "20",
-		},
+		UpdateSpec:               v1alpha1.DockerRegistrySpec{},
 	})
 	if err != nil {
 		log.Error(err)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- remote the `HealthzLivenessTimeout` type from the DockerRegistry CR because it's not used anywhere

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/docker-registry/issues/37#issue-2297243298