### PR TITLE
Split the `sFnRegistryConfiguration` function

### DIFF
--- a/components/operator/internal/state/initialize.go
+++ b/components/operator/internal/state/initialize.go
@@ -14,5 +14,5 @@ func sFnInitialize(_ context.Context, _ *reconciler, s *systemState) (stateFn, *
 		return nextState(sFnDeleteResources)
 	}
 
-	return nextState(sFnRegistryConfiguration)
+	return nextState(sFnAccessConfiguration)
 }

--- a/components/operator/internal/state/initialize_test.go
+++ b/components/operator/internal/state/initialize_test.go
@@ -34,7 +34,7 @@ func Test_sFnInitialize(t *testing.T) {
 		next, result, err := sFnInitialize(context.Background(), r, s)
 		require.Nil(t, err)
 		require.Nil(t, result)
-		requireEqualFunc(t, sFnRegistryConfiguration, next)
+		requireEqualFunc(t, sFnAccessConfiguration, next)
 	})
 
 	t.Run("setup and return next step sFnDeleteResources", func(t *testing.T) {

--- a/components/operator/internal/state/registry.go
+++ b/components/operator/internal/state/registry.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/kyma-project/docker-registry/components/operator/api/v1alpha1"
 	"github.com/kyma-project/docker-registry/components/operator/internal/registry"
@@ -10,10 +9,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func sFnRegistryConfiguration(ctx context.Context, r *reconciler, s *systemState) (stateFn, *ctrl.Result, error) {
+func sFnAccessConfiguration(ctx context.Context, r *reconciler, s *systemState) (stateFn, *ctrl.Result, error) {
 	s.setState(v1alpha1.StateProcessing)
-	// setup status.dockerRegistry and set possible warnings
-	err := configureRegistry(ctx, r, s)
+	err := setInternalAccessConfig(ctx, r, s)
 	if err != nil {
 		s.setState(v1alpha1.StateError)
 		s.instance.UpdateConditionFalse(
@@ -24,19 +22,10 @@ func sFnRegistryConfiguration(ctx context.Context, r *reconciler, s *systemState
 		return stopWithEventualError(err)
 	}
 
-	return nextState(sFnConfigurationStatus)
+	return nextState(sFnStorageConfiguration)
 }
 
-func configureRegistry(ctx context.Context, r *reconciler, s *systemState) error {
-	err := setInternalRegistryConfig(ctx, r, s)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func setInternalRegistryConfig(ctx context.Context, r *reconciler, s *systemState) error {
+func setInternalAccessConfig(ctx context.Context, r *reconciler, s *systemState) error {
 	existingIntRegSecret, err := registry.GetDockerRegistryInternalRegistrySecret(ctx, r.client, s.instance.Namespace)
 	if err != nil {
 		return errors.Wrap(err, "while fetching existing internal docker registry secret")
@@ -57,11 +46,6 @@ func setInternalRegistryConfig(ctx context.Context, r *reconciler, s *systemStat
 			)
 	}
 
-	err = prepareStorage(ctx, r, s) //s.instance.Spec.Storage, s.flagsBuilder)
-	if err != nil {
-		return errors.Wrap(err, "while preparing storage")
-	}
-
 	resolver := registry.NewNodePortResolver(registry.RandomNodePort)
 	nodePort, err := resolver.ResolveDockerRegistryNodePortFn(ctx, r.client, s.instance.Namespace)
 	if err != nil {
@@ -69,44 +53,5 @@ func setInternalRegistryConfig(ctx context.Context, r *reconciler, s *systemStat
 	}
 	r.log.Debugf("docker registry node port: %d", nodePort)
 	s.flagsBuilder.WithNodePort(int64(nodePort))
-	return nil
-}
-
-func prepareStorage(ctx context.Context, r *reconciler, s *systemState) error { //storage *v1alpha1.Storage, flagsBuilder chart.FlagsBuilder, s *systemState) {
-	if s.instance.Spec.Storage != nil {
-		if s.instance.Spec.Storage.Azure != nil {
-			return prepareAzureStorage(ctx, r, s)
-		} else if s.instance.Spec.Storage.S3 != nil {
-			return prepareS3Storage(ctx, r, s)
-		}
-	}
-	s.flagsBuilder.WithFilesystem()
-	return nil
-}
-
-func prepareAzureStorage(ctx context.Context, r *reconciler, s *systemState) error {
-	azureSecret, err := registry.GetSecret(ctx, r.client, s.instance.Spec.Storage.Azure.SecretName, s.instance.Namespace)
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("while fetching azure storage secret from %s", s.instance.Namespace))
-	}
-	storageAzureSecret := &v1alpha1.StorageAzureSecrets{
-		AccountName: string(azureSecret.Data["accountName"]),
-		AccountKey:  string(azureSecret.Data["accountKey"]),
-		Container:   string(azureSecret.Data["container"]),
-	}
-	s.flagsBuilder.WithAzure(storageAzureSecret)
-	return nil
-}
-
-func prepareS3Storage(ctx context.Context, r *reconciler, s *systemState) error {
-	s3Secret, err := registry.GetSecret(ctx, r.client, s.instance.Spec.Storage.S3.SecretName, s.instance.Namespace)
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("while fetching s3 storage secret from %s", s.instance.Namespace))
-	}
-	storageS3Secret := &v1alpha1.StorageS3Secrets{
-		AccessKey: string(s3Secret.Data["accessKey"]),
-		SecretKey: string(s3Secret.Data["secretKey"]),
-	}
-	s.flagsBuilder.WithS3(s.instance.Spec.Storage.S3, storageS3Secret)
 	return nil
 }

--- a/components/operator/internal/state/registry_test.go
+++ b/components/operator/internal/state/registry_test.go
@@ -1,0 +1,112 @@
+package state
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kyma-project/docker-registry/components/operator/api/v1alpha1"
+	"github.com/kyma-project/docker-registry/components/operator/internal/chart"
+	"github.com/kyma-project/docker-registry/components/operator/internal/registry"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func Test_sFnAccessConfiguration(t *testing.T) {
+	t.Run("setup node port only when registry secret does not exist", func(t *testing.T) {
+		s := &systemState{
+			instance:       v1alpha1.DockerRegistry{},
+			statusSnapshot: v1alpha1.DockerRegistryStatus{},
+			flagsBuilder:   chart.NewFlagsBuilder(),
+		}
+		r := &reconciler{
+			k8s: k8s{client: fake.NewClientBuilder().Build()},
+			log: zap.NewNop().Sugar(),
+		}
+		expectedFlags := map[string]interface{}{
+			"registryNodePort": int64(32_137),
+		}
+
+		next, result, err := sFnAccessConfiguration(context.Background(), r, s)
+		require.NoError(t, err)
+		require.Nil(t, result)
+		requireEqualFunc(t, sFnStorageConfiguration, next)
+
+		require.EqualValues(t, expectedFlags, s.flagsBuilder.Build())
+		require.Equal(t, v1alpha1.StateProcessing, s.instance.Status.State)
+	})
+
+	t.Run("setup node port and use existing username and password", func(t *testing.T) {
+		registrySecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      registry.SecretName,
+				Namespace: "kyma",
+				Labels: map[string]string{
+					registry.LabelConfigKey: registry.LabelConfigVal,
+				},
+			},
+			Data: map[string][]byte{
+				"isInternal": []byte("true"),
+				"username":   []byte("ala"),
+				"password":   []byte("makota"),
+			},
+		}
+
+		registryDeploy := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      registry.DeploymentName,
+				Namespace: "kyma",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Env: []corev1.EnvVar{
+									{
+										Name:  registry.HttpEnvKey,
+										Value: "httpEnvKeyVal",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		s := &systemState{
+			instance: v1alpha1.DockerRegistry{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "kyma",
+				},
+			},
+			statusSnapshot: v1alpha1.DockerRegistryStatus{},
+			flagsBuilder:   chart.NewFlagsBuilder(),
+		}
+		r := &reconciler{
+			k8s: k8s{client: fake.NewClientBuilder().WithObjects(registrySecret, registryDeploy).Build()},
+			log: zap.NewNop().Sugar(),
+		}
+		expectedFlags := map[string]interface{}{
+			"registryNodePort": int64(32_137),
+			"dockerRegistry": map[string]interface{}{
+				"username": "ala",
+				"password": "makota",
+			},
+			"registryHTTPSecret": "httpEnvKeyVal",
+			"rollme":             "dontrollplease",
+		}
+
+		next, result, err := sFnAccessConfiguration(context.Background(), r, s)
+		require.NoError(t, err)
+		require.Nil(t, result)
+		requireEqualFunc(t, sFnStorageConfiguration, next)
+
+		require.EqualValues(t, expectedFlags, s.flagsBuilder.Build())
+		require.Equal(t, v1alpha1.StateProcessing, s.instance.Status.State)
+	})
+}

--- a/components/operator/internal/state/storage.go
+++ b/components/operator/internal/state/storage.go
@@ -1,0 +1,66 @@
+package state
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kyma-project/docker-registry/components/operator/api/v1alpha1"
+	"github.com/kyma-project/docker-registry/components/operator/internal/registry"
+	"github.com/pkg/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func sFnStorageConfiguration(ctx context.Context, r *reconciler, s *systemState) (stateFn, *ctrl.Result, error) {
+	s.setState(v1alpha1.StateProcessing)
+	err := prepareStorage(ctx, r, s)
+	if err != nil {
+		s.setState(v1alpha1.StateError)
+		s.instance.UpdateConditionFalse(
+			v1alpha1.ConditionTypeConfigured,
+			v1alpha1.ConditionReasonConfigurationErr,
+			err,
+		)
+		return stopWithEventualError(err)
+	}
+
+	return nextState(sFnConfigurationStatus)
+}
+
+func prepareStorage(ctx context.Context, r *reconciler, s *systemState) error {
+	if s.instance.Spec.Storage != nil {
+		if s.instance.Spec.Storage.Azure != nil {
+			return prepareAzureStorage(ctx, r, s)
+		} else if s.instance.Spec.Storage.S3 != nil {
+			return prepareS3Storage(ctx, r, s)
+		}
+	}
+	s.flagsBuilder.WithFilesystem()
+	return nil
+}
+
+func prepareAzureStorage(ctx context.Context, r *reconciler, s *systemState) error {
+	azureSecret, err := registry.GetSecret(ctx, r.client, s.instance.Spec.Storage.Azure.SecretName, s.instance.Namespace)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("while fetching azure storage secret from %s", s.instance.Namespace))
+	}
+	storageAzureSecret := &v1alpha1.StorageAzureSecrets{
+		AccountName: string(azureSecret.Data["accountName"]),
+		AccountKey:  string(azureSecret.Data["accountKey"]),
+		Container:   string(azureSecret.Data["container"]),
+	}
+	s.flagsBuilder.WithAzure(storageAzureSecret)
+	return nil
+}
+
+func prepareS3Storage(ctx context.Context, r *reconciler, s *systemState) error {
+	s3Secret, err := registry.GetSecret(ctx, r.client, s.instance.Spec.Storage.S3.SecretName, s.instance.Namespace)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("while fetching s3 storage secret from %s", s.instance.Namespace))
+	}
+	storageS3Secret := &v1alpha1.StorageS3Secrets{
+		AccessKey: string(s3Secret.Data["accessKey"]),
+		SecretKey: string(s3Secret.Data["secretKey"]),
+	}
+	s.flagsBuilder.WithS3(s.instance.Spec.Storage.S3, storageS3Secret)
+	return nil
+}

--- a/components/operator/internal/state/storage_test.go
+++ b/components/operator/internal/state/storage_test.go
@@ -45,6 +45,18 @@ func Test_sFnStorageConfiguration(t *testing.T) {
 	})
 
 	t.Run("internal registry using azure storage", func(t *testing.T) {
+		azureSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "azureSecret",
+				Namespace: "kyma-system",
+			},
+			Data: map[string][]byte{
+				"accountName": []byte("accountName"),
+				"accountKey":  []byte("accountKey"),
+				"container":   []byte("container"),
+			},
+		}
+
 		s := &systemState{
 			instance: v1alpha1.DockerRegistry{
 				ObjectMeta: metav1.ObjectMeta{
@@ -62,21 +74,9 @@ func Test_sFnStorageConfiguration(t *testing.T) {
 			flagsBuilder:   chart.NewFlagsBuilder(),
 		}
 		r := &reconciler{
-			k8s: k8s{client: fake.NewClientBuilder().Build()},
+			k8s: k8s{client: fake.NewClientBuilder().WithObjects(azureSecret).Build()},
 			log: zap.NewNop().Sugar(),
 		}
-		azureSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "azureSecret",
-				Namespace: "kyma-system",
-			},
-			Data: map[string][]byte{
-				"accountName": []byte("accountName"),
-				"accountKey":  []byte("accountKey"),
-				"container":   []byte("container"),
-			},
-		}
-		require.NoError(t, r.k8s.client.Create(context.Background(), azureSecret))
 
 		expectedFlags := map[string]interface{}{
 			"storage": "azure",
@@ -98,6 +98,17 @@ func Test_sFnStorageConfiguration(t *testing.T) {
 		require.Equal(t, v1alpha1.StateProcessing, s.instance.Status.State)
 	})
 	t.Run("internal registry using s3 storage", func(t *testing.T) {
+		s3Secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "s3Secret",
+				Namespace: "kyma-system",
+			},
+			Data: map[string][]byte{
+				"accessKey": []byte("accessKey"),
+				"secretKey": []byte("secretKey"),
+			},
+		}
+
 		s := &systemState{
 			instance: v1alpha1.DockerRegistry{
 				ObjectMeta: metav1.ObjectMeta{
@@ -120,20 +131,9 @@ func Test_sFnStorageConfiguration(t *testing.T) {
 			flagsBuilder:   chart.NewFlagsBuilder(),
 		}
 		r := &reconciler{
-			k8s: k8s{client: fake.NewClientBuilder().Build()},
+			k8s: k8s{client: fake.NewClientBuilder().WithObjects(s3Secret).Build()},
 			log: zap.NewNop().Sugar(),
 		}
-		azureSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "s3Secret",
-				Namespace: "kyma-system",
-			},
-			Data: map[string][]byte{
-				"accessKey": []byte("accessKey"),
-				"secretKey": []byte("secretKey"),
-			},
-		}
-		require.NoError(t, r.k8s.client.Create(context.Background(), azureSecret))
 
 		expectedFlags := map[string]interface{}{
 			"storage": "s3",

--- a/components/operator/internal/state/storage_test.go
+++ b/components/operator/internal/state/storage_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func Test_sFnRegistryConfiguration(t *testing.T) {
+func Test_sFnStorageConfiguration(t *testing.T) {
 	t.Run("internal registry using default storage", func(t *testing.T) {
 		s := &systemState{
 			instance:       v1alpha1.DockerRegistry{},
@@ -32,11 +32,10 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 					},
 				},
 			},
-			"storage":          "filesystem",
-			"registryNodePort": int64(32_137),
+			"storage": "filesystem",
 		}
 
-		next, result, err := sFnRegistryConfiguration(context.Background(), r, s)
+		next, result, err := sFnStorageConfiguration(context.Background(), r, s)
 		require.NoError(t, err)
 		require.Nil(t, result)
 		requireEqualFunc(t, sFnConfigurationStatus, next)
@@ -88,10 +87,9 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 					"container":   "container",
 				},
 			},
-			"registryNodePort": int64(32_137),
 		}
 
-		next, result, err := sFnRegistryConfiguration(context.Background(), r, s)
+		next, result, err := sFnStorageConfiguration(context.Background(), r, s)
 		require.NoError(t, err)
 		require.Nil(t, result)
 		requireEqualFunc(t, sFnConfigurationStatus, next)
@@ -152,10 +150,9 @@ func Test_sFnRegistryConfiguration(t *testing.T) {
 					"secretKey": "secretKey",
 				},
 			},
-			"registryNodePort": int64(32_137),
 		}
 
-		next, result, err := sFnRegistryConfiguration(context.Background(), r, s)
+		next, result, err := sFnStorageConfiguration(context.Background(), r, s)
 		require.NoError(t, err)
 		require.Nil(t, result)
 		requireEqualFunc(t, sFnConfigurationStatus, next)

--- a/config/operator/base/crd/bases/operator.kyma-project.io_dockerregistries.yaml
+++ b/config/operator/base/crd/bases/operator.kyma-project.io_dockerregistries.yaml
@@ -55,10 +55,6 @@ spec:
           spec:
             description: DockerRegistrySpec defines the desired state of DockerRegistry
             properties:
-              healthzLivenessTimeout:
-                description: Sets the timeout for the Function health check. The default
-                  value in seconds is `10`
-                type: string
               storage:
                 properties:
                   azure:
@@ -160,8 +156,6 @@ spec:
                   - type
                   type: object
                 type: array
-              healthzLivenessTimeout:
-                type: string
               secretName:
                 type: string
               served:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- split the registry state function into storage and access config to make this state functions more single responsibility and open for further refactors and feature requests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/docker-registry/issues/37