### PR TITLE
Remove `isInternal` field

### DIFF
--- a/components/operator/internal/registry/secret.go
+++ b/components/operator/internal/registry/secret.go
@@ -12,7 +12,6 @@ const (
 	SecretName     = "dockerregistry-config"
 	LabelConfigKey = "dockerregistry.kyma-project.io/config"
 	LabelConfigVal = "credentials"
-	IsInternalKey  = "isInternal"
 	DeploymentName = "dockerregistry"
 	HttpEnvKey     = "REGISTRY_HTTP_SECRET"
 )
@@ -29,10 +28,6 @@ func GetDockerRegistryInternalRegistrySecret(ctx context.Context, c client.Clien
 	}
 
 	if val, ok := secret.GetLabels()[LabelConfigKey]; !ok || val != LabelConfigVal {
-		return nil, nil
-	}
-
-	if val := string(secret.Data[IsInternalKey]); val != "true" {
 		return nil, nil
 	}
 

--- a/components/operator/internal/state/registry_test.go
+++ b/components/operator/internal/state/registry_test.go
@@ -49,9 +49,8 @@ func Test_sFnAccessConfiguration(t *testing.T) {
 				},
 			},
 			Data: map[string][]byte{
-				"isInternal": []byte("true"),
-				"username":   []byte("ala"),
-				"password":   []byte("makota"),
+				"username": []byte("ala"),
+				"password": []byte("makota"),
 			},
 		}
 

--- a/config/docker-registry/templates/registry-config.yaml
+++ b/config/docker-registry/templates/registry-config.yaml
@@ -15,7 +15,6 @@ metadata:
 data:
   username: "{{ $username | b64enc }}"
   password: "{{ $password | b64enc }}"
-  isInternal: {{ "true" | b64enc }}
   pullRegAddr: {{ $internalRegPullAddr | b64enc }}
   pushRegAddr: "{{ $internalRegPushAddr | b64enc }}"
   .dockerconfigjson: "{{- (printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}, \"%s\": {\"auth\": \"%s\"}}}" $internalRegPushAddr $encodedUsernamePassword $internalRegPullAddr $encodedUsernamePassword) | b64enc }}"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- the `inInternal` field was used by the Serverless nad DockerRegistry is not a part of serverless any longer

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/docker-registry/issues/37