### PR TITLE
Warn user when custom gateway is not available

### DIFF
--- a/components/operator/internal/istio/istio.go
+++ b/components/operator/internal/istio/istio.go
@@ -35,3 +35,12 @@ func GetClusterAddressFromGateway(ctx context.Context, c client.Client) (string,
 	// host is always in format '*.<address>' so we need to remove the first two characters
 	return host[2:], nil
 }
+
+func IsGatewayAvailable(ctx context.Context, c client.Client, namespace, name string) bool {
+	err := c.Get(ctx, client.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}, &v1beta1.Gateway{})
+
+	return err == nil
+}

--- a/components/operator/internal/state/access.go
+++ b/components/operator/internal/state/access.go
@@ -2,10 +2,10 @@ package state
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/kyma-project/docker-registry/components/operator/api/v1alpha1"
 	"github.com/kyma-project/docker-registry/components/operator/internal/chart"
-	"github.com/kyma-project/docker-registry/components/operator/internal/istio"
 	"github.com/kyma-project/docker-registry/components/operator/internal/registry"
 	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -78,8 +78,9 @@ func setExternalAccessConfig(ctx context.Context, r *reconciler, s *systemState)
 	resolvedAccess, err := s.gatewayHostResolver.Do(ctx, r.client, *spec.ExternalAccess)
 	if err != nil {
 		// set warning and continue reconciliation because external access is optional
-		s.warningBuilder.With(".spec.externalAccess.enabled is true but the kyma-gateway Gateway in the kyma-system namespace is not found")
-		r.log.Warnf("%s/%s gateway not found: %s", istio.GatewayNamespace, istio.GatewayName, err)
+		msg := fmt.Sprintf(".spec.externalAccess.enabled is true but got error: %s", err.Error())
+		s.warningBuilder.With(msg)
+		r.log.Warnf(msg)
 		return nil
 	}
 

--- a/components/operator/internal/state/access_test.go
+++ b/components/operator/internal/state/access_test.go
@@ -243,6 +243,6 @@ func Test_sFnAccessConfiguration(t *testing.T) {
 
 		require.EqualValues(t, expectedFlags, s.flagsBuilder.Build())
 
-		require.Equal(t, "Warning: .spec.externalAccess.enabled is true but the kyma-gateway Gateway in the kyma-system namespace is not found", s.warningBuilder.Build())
+		require.Equal(t, "Warning: .spec.externalAccess.enabled is true but got error: while getting Gateway kyma-gateway in namespace kyma-system: gatewaies.networking.istio.io \"kyma-gateway\" not found", s.warningBuilder.Build())
 	})
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- set warning if custom gateway is not available
- fix warning message

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/docker-registry/issues/106#issue-2424710286