### PR TITLE
Fix retrying for req avail checks

### DIFF
--- a/tests/btp/hack/registry-availibility-check.sh
+++ b/tests/btp/hack/registry-availibility-check.sh
@@ -1,39 +1,26 @@
 #!/bin/sh
-set -e
+set -e -o pipefail
 
 USERNAME=$(kubectl get secrets -n kyma-system dockerregistry-config-external -o jsonpath={.data.username} --kubeconfig ${KUBECONFIG} | base64 -d)
 PASSWORD=$(kubectl get secrets -n kyma-system dockerregistry-config-external -o jsonpath={.data.password} --kubeconfig ${KUBECONFIG} | base64 -d)
 REGISTRY_URL=$(kubectl get dockerregistries.operator.kyma-project.io -n kyma-system default -ojsonpath={.status.externalAccess.pushAddress} --kubeconfig ${KUBECONFIG})
 
-echo $USERNAME
-echo $PASSWORD
 
 echo Testing Docker Registry availibility at: $REGISTRY_URL
 
+# TODO: https://github.tools.sap/otters/kyma-automation-demo/issues/5
+sleep 10
+
 COUNTER=0
-RESPONSE_CODE=$(curl  -o /dev/null -u $USERNAME:$PASSWORD -L -w ''%{http_code}'' --connect-timeout 5 \
+RESPONSE_CODE=$(curl -o /dev/null -u $USERNAME:$PASSWORD -L -w ''%{http_code}'' --connect-timeout 5 \
     --max-time 10 \
-    --retry 5 \
-    --retry-delay 0 \
-    --retry-max-time 40 $REGISTRY_URL )
+    --retry 15 \
+    --retry-delay 5 \
+    --retry-max-time 40 $REGISTRY_URL 2>/dev/null)
 echo Response from registry: $RESPONSE_CODE
-if [ $RESPONSE_CODE == '200' ]; then
+if [ "$RESPONSE_CODE" == "200" ]; then
     exit 0
 fi
-until [[ $COUNTER -gt 10  ||  $RESPONSE_CODE == "200" ]] ;
-do
-    sleep 5
-    let COUNTER=COUNTER+1 
-    RESPONSE_CODE=$(curl -s -o /dev/null -u $USERNAME:$PASSWORD -L -w ''%{http_code}'' --connect-timeout 5 \
-    --max-time 10 \
-    --retry 5 \
-    --retry-delay 0 \
-    --retry-max-time 40 $REGISTRY_URL )
-    echo Response from registry: $RESPONSE_CODE
-    if [ $RESPONSE_CODE == '200' ]; then
-        exit 0
-    fi
-done
 
 echo "ERROR"
 exit 1


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- rework avail. check as it [fails](https://github.com/kyma-project/docker-registry/actions/runs/11741523966/job/32724522077#step:6:97). In [ci-demo](https://github.tools.sap/kyma/ci-automation-demo/blob/main/ci/registry-availibility-check.sh) it works


