### PR TITLE
Properly check main status before release

### DIFF
--- a/.github/scripts/verify-actions-status.sh
+++ b/.github/scripts/verify-actions-status.sh
@@ -6,7 +6,7 @@ REF_NAME="${1:-"main"}"
 RAW_EXPECTED_SHA=$(git log "${REF_NAME}" --max-count 1 --format=format:%H)
 REPOSITORY_ID="563346860"
 
-STATUS_URL="https://api.github.com/repositories/${REPOSITORY_ID}/actions/workflows/gardener-integration.yaml/runs?head_sha=${RAW_EXPECTED_SHA}"
+STATUS_URL="https://api.github.com/repositories/${REPOSITORY_ID}/actions/workflows/push.yaml/runs?head_sha=${RAW_EXPECTED_SHA}"
 GET_STATUS_JQ_QUERY=".workflow_runs[0] | \"\(.status)-\(.conclusion)\""
 GET_COUNT_JQ_QUERY=".total_count"
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- gardener tests are gone. No need to check them upon release. Check all `push` CI workflows instead