### PR TITLE
Cherry-pick: Use latest stable CLI in integration tests (#323)

### DIFF
--- a/.github/actions/setup-kyma/action.yaml
+++ b/.github/actions/setup-kyma/action.yaml
@@ -14,4 +14,5 @@ runs:
       shell: bash
       run: |
         mkdir -p ${{ inputs.path }}
-        curl -s -L "https://github.com/kyma-project/cli/releases/download/v0.0.0-dev/kyma_$(uname -s)_$(uname -m).tar.gz" | tar -zxvf - -C ${{ inputs.path }} kyma
+        VERSION=$(curl -sL https://api.github.com/repos/kyma-project/cli/releases/latest | jq -r '.tag_name')
+        curl -s -L "https://github.com/kyma-project/cli/releases/download/${VERSION}/kyma_$(uname -s)_$(uname -m).tar.gz" | tar -zxvf - -C ${{ inputs.path }} kyma


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- cherry-pick https://github.com/kyma-project/docker-registry/pull/323

