### PR TITLE
Stop using configPath in cli extension

### DIFF
--- a/config/docker-registry/files/kyma-commands.yaml
+++ b/config/docker-registry/files/kyma-commands.yaml
@@ -13,18 +13,18 @@ subCommands:
   - type: bool
     name: "push-reg-addr"
     description: "Get external registry push address only"
-    configPath: ".pushRegAddrOnly"
     default: "false"
   - type: bool
     name: "pull-reg-addr"
     description: "Get external registry address used to pull images"
-    configPath: ".pullRegAddrOnly"
     default: "false"
   - type: string
     name: "output"
     description: "Path where the output file should be saved to. NOTE: docker expects the file to be named 'config.json'"
-    configPath: ".output"
   with:
+    pushRegAddrOnly: ${{  .flags.pushregaddr.value }}
+    pullRegAddrOnly: ${{  .flags.pullregaddr.value }}
+    output: ${{  .flags.output.value }}
     useExternal: true
 
 - metadata:
@@ -36,18 +36,18 @@ subCommands:
   - type: bool
     name: "push-reg-addr"
     description: "Get in-cluster registry address only"
-    configPath: ".pushRegAddrOnly"
     default: "false"
   - type: bool
     name: "pull-reg-addr"
     description: "Get in-cluster registry address used to pull images by Kubernetes only"
-    configPath: ".pullRegAddrOnly"
     default: "false"
   - type: string
     name: "output"
     description: "Path where the output file should be saved to. NOTE: docker expects the file to be named 'config.json'"
-    configPath: ".output"
   with:
+    pushRegAddrOnly: ${{  .flags.pushregaddr.value }}
+    pullRegAddrOnly: ${{  .flags.pullregaddr.value }}
+    output: ${{  .flags.output.value }}
     useExternal: false
 
 - metadata:
@@ -57,4 +57,5 @@ subCommands:
   uses: registry_image_import
   args:
     type: string
-    configPath: ".image"
+  with:
+    image: ${{ .args.value}}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- migrate from the `configPath` inside the `flags` and `args` into go templates in the `with` config

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/cli/issues/2428