### PR TITLE
Revert "Migrate the `kyma registry` extension (#346)"

### DIFF
--- a/docs/user/tutorials/01-10-use-registry-internally.md
+++ b/docs/user/tutorials/01-10-use-registry-internally.md
@@ -42,7 +42,7 @@ This tutorial shows how you can push an image to the Docker Registry and use it.
 4. Import the image to Docker Registry:
 
    ```bash
-   kyma registry image-import simple-image:latest
+   kyma alpha registry image-import simple-image:latest
    ```
 
 4. Create a Pod using the image from Docker Registry:

--- a/docs/user/tutorials/01-30-remove-image-manifest.md
+++ b/docs/user/tutorials/01-30-remove-image-manifest.md
@@ -37,7 +37,7 @@ status:
 2. Push the image to the registry:
 
 ```bash
-kyma registry image-import <IMAGE_NAME>:<IMAGE_TAG>
+kyma alpha registry image-import <IMAGE_NAME>:<IMAGE_TAG>
 ```
 
 3. Port-forward the registry service to another terminal:

--- a/tests/btp/Makefile
+++ b/tests/btp/Makefile
@@ -1,6 +1,6 @@
 .PHONY: docker_push_simple_app
 docker_push_simple_app:
-	@kyma registry config-external --output config.json
+	@kyma alpha registry config --output config.json
 	# TODO: get multiplatform nginx; now we get nginx for amd64
 	docker pull nginx@sha256:f05d105face814474acc5538160bd3f29309d9398dd895a4e71f676a4fd9a3fc
 	docker tag nginx@sha256:f05d105face814474acc5538160bd3f29309d9398dd895a4e71f676a4fd9a3fc $$(kubectl get dockerregistries.operator.kyma-project.io -n kyma-system default -ojsonpath={.status.externalAccess.pushAddress})/simple-app:0.0.1


### PR DESCRIPTION
This reverts commit f470c1a2ea2f66b64b5f344d2581bb50148c7f5a.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- revert commit to support old CLI (new one is not released yet)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/docker-registry/issues/369