### PR TITLE
Remove build-engine: buildx

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -43,7 +43,6 @@ jobs:
       name: dockerregistry-operator
       dockerfile: components/operator/Dockerfile
       tags: ${{ needs.compute-tags.outputs.tags }}
-      build-engine: buildx
 
   build-registry-init:
     needs: compute-tags
@@ -52,4 +51,3 @@ jobs:
       name: registry-init
       dockerfile: components/registry-init/Dockerfile
       tags: ${{ needs.compute-tags.outputs.tags }}
-      build-engine: buildx


### PR DESCRIPTION
This PR removes the deprecated `build-engine: buildx` entry from workflows.