### PR TITLE
Remove dependency to Kyma CLI v2

### DIFF
--- a/hack/k3d.mk
+++ b/hack/k3d.mk
@@ -10,8 +10,9 @@ include $(PROJECT_ROOT)/hack/tools.mk
 ##@ K3D
 
 .PHONY: create-k3d
-create-k3d: kyma ## Create k3d with kyma CRDs.
-	${KYMA} provision k3d --registry-port ${REGISTRY_PORT} --name ${CLUSTER_NAME} --ci -p 6080:8080@loadbalancer -p 6433:8433@loadbalancer
+create-k3d: delete-k3d ## Delete old k3d registry and cluster. Create preconfigured k3d with registry
+	k3d registry create ${REGISTRY_NAME} --port ${REGISTRY_PORT} --no-help
+	k3d cluster create ${CLUSTER_NAME} --registry-use "k3d-${REGISTRY_NAME}:${REGISTRY_PORT}"
 	kubectl create namespace kyma-system
 
 .PHONY: delete-k3d


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use k3d CLI to provision k3d instead of deprecated v2 `kyma provision k3d` command

**Related issue(s)**
https://github.com/kyma-project/cli/issues/2051