### PR TITLE
Set defaults to empty string

### DIFF
--- a/config/docker-registry/files/kyma-commands.yaml
+++ b/config/docker-registry/files/kyma-commands.yaml
@@ -21,7 +21,7 @@ subCommands:
   - type: string
     name: "output"
     description: "Path where the output file should be saved to. NOTE: docker expects the file to be named 'config.json'"
-    default: "./config.json"
+    default: ""
   with:
     pushRegAddrOnly: ${{  .flags.pushregaddr.value }}
     pullRegAddrOnly: ${{  .flags.pullregaddr.value }}
@@ -45,7 +45,7 @@ subCommands:
   - type: string
     name: "output"
     description: "Path where the output file should be saved to. NOTE: docker expects the file to be named 'config.json'"
-    default: "./config.json"
+    default: ""
   with:
     pushRegAddrOnly: ${{  .flags.pushregaddr.value }}
     pullRegAddrOnly: ${{  .flags.pullregaddr.value }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
As in title, when set to empty string the config is printed on console

**Related issue(s)**
https://github.com/kyma-project/docker-registry/issues/420
