### PR TITLE
Take care about the non-served DockerRegistry CR even after second CR was removed

### DIFF
--- a/components/operator/internal/state/served_filter.go
+++ b/components/operator/internal/state/served_filter.go
@@ -9,19 +9,16 @@ import (
 )
 
 func sFnServedFilter(ctx context.Context, r *reconciler, s *systemState) (stateFn, *ctrl.Result, error) {
-	if s.instance.IsServedEmpty() {
-		if err := setInitialServed(ctx, r, s); err != nil {
+	if s.instance.IsServedEmpty() || s.instance.Status.Served == v1alpha1.ServedFalse {
+		if err := calculateServed(ctx, r, s); err != nil {
 			return stopWithEventualError(err)
 		}
 	}
 
-	if s.instance.Status.Served == v1alpha1.ServedFalse {
-		return stop()
-	}
 	return nextState(sFnAddFinalizer)
 }
 
-func setInitialServed(ctx context.Context, r *reconciler, s *systemState) error {
+func calculateServed(ctx context.Context, r *reconciler, s *systemState) error {
 	servedDockerRegistry, err := GetServedDockerRegistry(ctx, r.k8s.client)
 	if err != nil {
 		return err

--- a/components/operator/internal/state/served_filter_test.go
+++ b/components/operator/internal/state/served_filter_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_sFnServedFilter(t *testing.T) {
-	t.Run("skip processing when served is false", func(t *testing.T) {
+	t.Run("re-processing when served is false", func(t *testing.T) {
 		s := &systemState{
 			instance: v1alpha1.DockerRegistry{
 				Status: v1alpha1.DockerRegistryStatus{
@@ -22,10 +22,17 @@ func Test_sFnServedFilter(t *testing.T) {
 			},
 		}
 
-		nextFn, result, err := sFnServedFilter(context.TODO(), nil, s)
+		r := &reconciler{
+			k8s: k8s{
+				client: fixClient(t),
+			},
+		}
+
+		nextFn, result, err := sFnServedFilter(context.TODO(), r, s)
 		require.Nil(t, err)
 		require.Nil(t, result)
-		require.Nil(t, nextFn)
+		requireEqualFunc(t, sFnAddFinalizer, nextFn)
+		require.Equal(t, v1alpha1.ServedTrue, s.instance.Status.Served)
 	})
 
 	t.Run("do next step when served is true", func(t *testing.T) {
@@ -52,21 +59,12 @@ func Test_sFnServedFilter(t *testing.T) {
 
 		r := &reconciler{
 			k8s: k8s{
-				client: func() client.Client {
-					scheme := apiruntime.NewScheme()
-					require.NoError(t, v1alpha1.AddToScheme(scheme))
-
-					client := fake.NewClientBuilder().
-						WithScheme(scheme).
-						WithObjects(
-							fixServedDockerRegistry("test-1", "default", ""),
-							fixServedDockerRegistry("test-2", "dockerregistry-test", v1alpha1.ServedFalse),
-							fixServedDockerRegistry("test-3", "dockerregistry-test-2", ""),
-							fixServedDockerRegistry("test-4", "default", v1alpha1.ServedFalse),
-						).Build()
-
-					return client
-				}(),
+				client: fixClient(t,
+					fixServedDockerRegistry("test-1", "default", ""),
+					fixServedDockerRegistry("test-2", "dockerregistry-test", ""),
+					fixServedDockerRegistry("test-3", "dockerregistry-test-2", ""),
+					fixServedDockerRegistry("test-4", "default", ""),
+				),
 			},
 		}
 
@@ -86,21 +84,12 @@ func Test_sFnServedFilter(t *testing.T) {
 
 		r := &reconciler{
 			k8s: k8s{
-				client: func() client.Client {
-					scheme := apiruntime.NewScheme()
-					require.NoError(t, v1alpha1.AddToScheme(scheme))
-
-					client := fake.NewClientBuilder().
-						WithScheme(scheme).
-						WithObjects(
-							fixServedDockerRegistry("test-1", "default", v1alpha1.ServedFalse),
-							fixServedDockerRegistry("test-2", "dockerregistry-test", v1alpha1.ServedTrue),
-							fixServedDockerRegistry("test-3", "dockerregistry-test-2", ""),
-							fixServedDockerRegistry("test-4", "default", v1alpha1.ServedFalse),
-						).Build()
-
-					return client
-				}(),
+				client: fixClient(t,
+					fixServedDockerRegistry("test-1", "default", v1alpha1.ServedFalse),
+					fixServedDockerRegistry("test-2", "dockerregistry-test", v1alpha1.ServedTrue),
+					fixServedDockerRegistry("test-3", "dockerregistry-test-2", ""),
+					fixServedDockerRegistry("test-4", "default", v1alpha1.ServedFalse),
+				),
 			},
 		}
 
@@ -121,6 +110,15 @@ func Test_sFnServedFilter(t *testing.T) {
 			expectedErrorMessage,
 		)
 	})
+}
+
+func fixClient(t *testing.T, initObjs ...client.Object) client.Client {
+	scheme := apiruntime.NewScheme()
+	require.NoError(t, v1alpha1.AddToScheme(scheme))
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(initObjs...).Build()
 }
 
 func fixServedDockerRegistry(name, namespace string, served v1alpha1.Served) *v1alpha1.DockerRegistry {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- requeue all DockerRegistry CRs after one of them is removed (to recalculated the `.status.served` field)
- recalculate the `.status.served` field on every reconciliation to give all resources a "second chance" 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/serverless/issues/1963