### PR TITLE
Include release report uploader job into dockerregistry releaser workflow

### DIFF
--- a/.github/workflows/create-release-on-tag.yaml
+++ b/.github/workflows/create-release-on-tag.yaml
@@ -12,6 +12,7 @@ on:
 permissions: # used by build images steps
   id-token: write # This is required for requesting the JWT token
   contents: write # This is required for actions/checkout
+  actions: read # This is required for uploading release reports
 
 
 jobs:
@@ -84,3 +85,12 @@ jobs:
             latest_release="true"
           fi
           ./.github/scripts/publish-release.sh ${{ needs.create-draft.outputs.release_id }} ${latest_release}
+
+  upload-release-report:
+    needs: [integrations]
+    if: ${{ needs.integrations.result == 'success' }}
+    uses: kyma-project/compliancy/.github/workflows/upload-release-report.yml@main
+    with:
+      release_version: ${{ github.ref_name }}
+    secrets:
+     RELEASE_LOG_UPLOADER_SA: ${{ secrets.RELEASE_LOG_UPLOADER_SA }}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Enable audit-ability of test results executed on each docker-registry release
