### PR TITLE
fix(btp-tests): use docker-registry namespace for BTP resources

### DIFF
--- a/tests/btp/Makefile
+++ b/tests/btp/Makefile
@@ -25,7 +25,7 @@ deploy_simple_app:
 ensure-btp-object-store-backend:
 # create reference instance (and binding) to an existing btp object store service instance that is shared via credentials to remote service manager from different subaccount.
 	@kubectl create secret generic remote-service-manager-credentials \
-		--namespace kyma-system --from-env-file sm.env
+		--namespace docker-registry --from-env-file sm.env
 	@echo "Waiting for CRD btp operator"
 	@while ! kubectl get crd btpoperators.operator.kyma-project.io; \
 		do echo "Waiting for CRD btp operator..."; sleep 1; done
@@ -35,12 +35,12 @@ ensure-btp-object-store-backend:
 	@kubectl wait --for condition=Ready btpoperators.operator.kyma-project.io/btpoperator -n kyma-system --timeout=180s
 	@kyma alpha reference-instance \
 		--btp-secret-name remote-service-manager-credentials \
-		--namespace kyma-system \
+		--namespace docker-registry \
 		--offering-name objectstore \
 		--plan-selector standard \
 		--reference-name object-store-reference
-	@kubectl apply -n kyma-system -f k8s-resources/dependencies/object-store-binding.yaml
-	@while ! kubectl get secret object-store-reference-binding --namespace kyma-system; \
+	@kubectl apply -n docker-registry -f k8s-resources/dependencies/object-store-binding.yaml
+	@while ! kubectl get secret object-store-reference-binding --namespace docker-registry; \
 		do echo "Waiting for object-store-reference-binding secret..."; sleep 5; done
 
 .PHONY: enable_docker_registry
@@ -66,8 +66,8 @@ test: docker_push_simple_app deploy_simple_app cleanup-kyma
 cleanup-kyma:
 	@echo "Deleting resources from kyma..."
 	@kubectl delete -f k8s-resources/simple-app
-	@kubectl delete -n kyma-system servicebindings.services.cloud.sap.com --all
-	@kubectl delete -n kyma-system serviceinstances.services.cloud.sap.com --all
+	@kubectl delete -n docker-registry servicebindings.services.cloud.sap.com --all
+	@kubectl delete -n docker-registry serviceinstances.services.cloud.sap.com --all
 
 .PHONY: cluster-info
 cluster-info: ## Print useful info about the cluster regarding integration run


### PR DESCRIPTION
After PR #503 moved docker-registry to its own namespace, the operator looks for the BTP storage secret in `instance.Namespace` (docker-registry), but the tests were still creating all BTP resources in kyma-system.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Use the docker-registry namespace for BTP resources

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
