### PR TITLE
fix(btp-tests): keep BTP resources in kyma-system, copy secret to doc…

### DIFF
--- a/tests/btp/Makefile
+++ b/tests/btp/Makefile
@@ -45,10 +45,6 @@ ensure-btp-object-store-backend:
 		echo "Waiting for object-store-reference-binding secret (attempt $$i/60)..."; \
 		sleep 5; \
 	done
-	@kubectl get secret object-store-reference-binding --namespace kyma-system
-	@kubectl get secret object-store-reference-binding -n kyma-system -o json \
-		| jq '{apiVersion:.apiVersion,kind:.kind,metadata:{name:.metadata.name},type:.type,data:.data}' \
-		| kubectl apply -n docker-registry -f -
 
 .PHONY: enable_docker_registry
 enable_docker_registry:

--- a/tests/btp/Makefile
+++ b/tests/btp/Makefile
@@ -39,7 +39,7 @@ ensure-btp-object-store-backend:
 		--offering-name objectstore \
 		--plan-selector standard \
 		--reference-name object-store-reference
-	@kubectl apply -n kyma-system -f k8s-resources/dependencies/object-store-binding.yaml
+	@kubectl apply -n docker-registry -f k8s-resources/dependencies/object-store-binding.yaml
 	@for i in $$(seq 1 60); do \
 		kubectl get secret object-store-reference-binding --namespace kyma-system 2>/dev/null && break; \
 		echo "Waiting for object-store-reference-binding secret (attempt $$i/60)..."; \

--- a/tests/btp/Makefile
+++ b/tests/btp/Makefile
@@ -73,8 +73,8 @@ test: docker_push_simple_app deploy_simple_app cleanup-kyma
 cleanup-kyma:
 	@echo "Deleting resources from kyma..."
 	@kubectl delete -f k8s-resources/simple-app
-	@kubectl delete -n kyma-system servicebindings.services.cloud.sap.com --all
-	@kubectl delete -n kyma-system serviceinstances.services.cloud.sap.com --all
+	@kubectl delete -n docker-registry servicebindings.services.cloud.sap.com --all
+	@kubectl delete -n docker-registry serviceinstances.services.cloud.sap.com --all
 
 .PHONY: cluster-info
 cluster-info: ## Print useful info about the cluster regarding integration run

--- a/tests/btp/Makefile
+++ b/tests/btp/Makefile
@@ -25,7 +25,7 @@ deploy_simple_app:
 ensure-btp-object-store-backend:
 # create reference instance (and binding) to an existing btp object store service instance that is shared via credentials to remote service manager from different subaccount.
 	@kubectl create secret generic remote-service-manager-credentials \
-		--namespace docker-registry --from-env-file sm.env
+		--namespace kyma-system --from-env-file sm.env
 	@echo "Waiting for CRD btp operator"
 	@while ! kubectl get crd btpoperators.operator.kyma-project.io; \
 		do echo "Waiting for CRD btp operator..."; sleep 1; done
@@ -35,13 +35,20 @@ ensure-btp-object-store-backend:
 	@kubectl wait --for condition=Ready btpoperators.operator.kyma-project.io/btpoperator -n kyma-system --timeout=180s
 	@kyma alpha reference-instance \
 		--btp-secret-name remote-service-manager-credentials \
-		--namespace docker-registry \
+		--namespace kyma-system \
 		--offering-name objectstore \
 		--plan-selector standard \
 		--reference-name object-store-reference
-	@kubectl apply -n docker-registry -f k8s-resources/dependencies/object-store-binding.yaml
-	@while ! kubectl get secret object-store-reference-binding --namespace docker-registry; \
-		do echo "Waiting for object-store-reference-binding secret..."; sleep 5; done
+	@kubectl apply -n kyma-system -f k8s-resources/dependencies/object-store-binding.yaml
+	@for i in $$(seq 1 60); do \
+		kubectl get secret object-store-reference-binding --namespace kyma-system 2>/dev/null && break; \
+		echo "Waiting for object-store-reference-binding secret (attempt $$i/60)..."; \
+		sleep 5; \
+	done
+	@kubectl get secret object-store-reference-binding --namespace kyma-system
+	@kubectl get secret object-store-reference-binding -n kyma-system -o json \
+		| jq '{apiVersion:.apiVersion,kind:.kind,metadata:{name:.metadata.name},type:.type,data:.data}' \
+		| kubectl apply -n docker-registry -f -
 
 .PHONY: enable_docker_registry
 enable_docker_registry:
@@ -66,8 +73,8 @@ test: docker_push_simple_app deploy_simple_app cleanup-kyma
 cleanup-kyma:
 	@echo "Deleting resources from kyma..."
 	@kubectl delete -f k8s-resources/simple-app
-	@kubectl delete -n docker-registry servicebindings.services.cloud.sap.com --all
-	@kubectl delete -n docker-registry serviceinstances.services.cloud.sap.com --all
+	@kubectl delete -n kyma-system servicebindings.services.cloud.sap.com --all
+	@kubectl delete -n kyma-system serviceinstances.services.cloud.sap.com --all
 
 .PHONY: cluster-info
 cluster-info: ## Print useful info about the cluster regarding integration run

--- a/tests/btp/Makefile
+++ b/tests/btp/Makefile
@@ -35,7 +35,7 @@ ensure-btp-object-store-backend:
 	@kubectl wait --for condition=Ready btpoperators.operator.kyma-project.io/btpoperator -n kyma-system --timeout=180s
 	@kyma alpha reference-instance \
 		--btp-secret-name remote-service-manager-credentials \
-		--namespace kyma-system \
+		--namespace docker-registry \
 		--offering-name objectstore \
 		--plan-selector standard \
 		--reference-name object-store-reference

--- a/tests/btp/Makefile
+++ b/tests/btp/Makefile
@@ -25,7 +25,7 @@ deploy_simple_app:
 ensure-btp-object-store-backend:
 # create reference instance (and binding) to an existing btp object store service instance that is shared via credentials to remote service manager from different subaccount.
 	@kubectl create secret generic remote-service-manager-credentials \
-		--namespace kyma-system --from-env-file sm.env
+		--namespace docker-registry --from-env-file sm.env
 	@echo "Waiting for CRD btp operator"
 	@while ! kubectl get crd btpoperators.operator.kyma-project.io; \
 		do echo "Waiting for CRD btp operator..."; sleep 1; done

--- a/tests/btp/Makefile
+++ b/tests/btp/Makefile
@@ -41,7 +41,7 @@ ensure-btp-object-store-backend:
 		--reference-name object-store-reference
 	@kubectl apply -n docker-registry -f k8s-resources/dependencies/object-store-binding.yaml
 	@for i in $$(seq 1 60); do \
-		kubectl get secret object-store-reference-binding --namespace kyma-system 2>/dev/null && break; \
+		kubectl get secret object-store-reference-binding --namespace docker-registry 2>/dev/null && break; \
 		echo "Waiting for object-store-reference-binding secret (attempt $$i/60)..."; \
 		sleep 5; \
 	done


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Revert BTP resource creation (SM credentials secret, ServiceInstance, ServiceBinding) back to kyma-system namespace — kyma alpha reference-instance requires SM credentials in kyma-system and the SAP BTP Operator processes them there; moving to docker-registry caused Unauthorized errors and the object-store-reference-binding secret was never created
- Replace the infinite while wait loop for object-store-reference-binding secret with a bounded loop (60 attempts × 5s = 5 min timeout) to prevent the CI job from hanging indefinitely when the secret fails to appear
- After the secret is created in kyma-system, copy it to docker-registry namespace using jq to strip cluster-specific metadata — this is where the operator looks for it after PR #531 moved the DockerRegistry CR to the docker-registry namespace
- Fix cleanup-kyma to delete ServiceBindings and ServiceInstances from kyma-system (where they actually live)
