### PR TITLE
sec: harden pull_request_target workflow against secret exfiltration

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -19,11 +19,6 @@ jobs:
     outputs:
       tags: ${{ steps.get_tag.outputs.TAGS }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - if: ${{ !startsWith(github.event_name, 'pull_request') }}
         name: Get the latest tag
         id: get_tag

--- a/.github/workflows/pull.yaml
+++ b/.github/workflows/pull.yaml
@@ -5,7 +5,6 @@ on:
     types: [ opened, edited, synchronize, reopened, ready_for_review ]
 
 permissions:
-  id-token: write # This is required for requesting the JWT token
   contents: read # This is required for actions/checkout
 
 jobs:
@@ -17,11 +16,13 @@ jobs:
     uses: ./.github/workflows/_images-verify.yaml
 
   builds:
+    permissions:
+      id-token: write # This is required for requesting the JWT token
+      contents: read # This is required for actions/checkout
     uses: ./.github/workflows/_build.yaml
 
   integrations:
     needs: builds
-    secrets: inherit
     uses: ./.github/workflows/_integration-tests.yaml
     with:
       image: europe-docker.pkg.dev/kyma-project/dev/dockerregistry-operator:PR-${{ github.event.number }}


### PR DESCRIPTION
## Summary

- **Scope `id-token: write` to `builds` job only** — was set at workflow level, making the OIDC token available to all jobs including `unit-tests`, `images-verify`, and `integrations` which don't need it
- **Remove `secrets: inherit` from `integrations` job** — no secrets are consumed by the jobs that actually run on PRs (`operator-integration-test`); the only secret-dependent job (`btp-integration-tests`) is already gated behind `trigger_btp: true` which is not passed from `pull.yaml`
- **Remove unnecessary PR head checkout from `compute-tags` job** in `_build.yaml` — the checkout fetched untrusted fork code in a privileged (`id-token: write`) context, but the only step that used checked-out files was already skipped on PR events

## Security impact

The `pull_request_target` trigger runs in the base branch context with write permissions and access to secrets. These changes apply least-privilege principles to reduce the blast radius if any job is compromised by malicious fork PR code.