### PR TITLE
Add namespaceSelector to metrics NetworkPolicy for RMA

### DIFF
--- a/config/docker-registry/templates/network-policy.yaml
+++ b/config/docker-registry/templates/network-policy.yaml
@@ -43,7 +43,10 @@ spec:
           podSelector:
             matchLabels:
               app.kubernetes.io/instance: rma
-        - podSelector:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kyma-system
+          podSelector:
             matchLabels:
               networking.kyma-project.io/metrics-scraping: allowed
       ports:

--- a/config/docker-registry/templates/network-policy.yaml
+++ b/config/docker-registry/templates/network-policy.yaml
@@ -37,7 +37,10 @@ spec:
     - Ingress
   ingress:
     - from:
-        - podSelector:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kyma-system
+          podSelector:
             matchLabels:
               app.kubernetes.io/instance: rma
         - podSelector:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add namespaceSelector to metrics NetworkPolicy so RMA in kyma-system can scrape docker-registry metrics

**Related issue(s)**
See also:
- https://github.tools.sap/kyma/backlog/issues/9617