### PR TITLE
Disable integration tests due to changes to checkout

### DIFF
--- a/.github/workflows/pull-build.yaml
+++ b/.github/workflows/pull-build.yaml
@@ -25,9 +25,13 @@ jobs:
       contents: read # This is required for actions/checkout
     uses: ./.github/workflows/_build.yaml
 
-  integrations:
-    needs: builds
-    uses: ./.github/workflows/_integration-tests.yaml
-    with:
-      image: europe-docker.pkg.dev/kyma-project/dev/dockerregistry-operator:PR-${{ github.event.number }}
+
+# Integration tests are intentionally disabled for pull_request_target.
+# actions/checkout@v7 blocks fork checkouts in pull_request_target by default (safer-pull_request_target-defaults).
+# Only the build job above runs here - it uses id-token to push images but does not expose secrets to untrusted fork code.
+#  integrations:
+#    needs: builds
+#    uses: ./.github/workflows/_integration-tests.yaml
+#    with:
+#      image: europe-docker.pkg.dev/kyma-project/dev/dockerregistry-operator:PR-${{ github.event.number }}
 


### PR DESCRIPTION
**Description**
Integrations test will run on merge only now

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
