### PR TITLE
Release the config Secret finalizer during module deletion

### DIFF
--- a/components/operator/controllers/controller_test.go
+++ b/components/operator/controllers/controller_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -75,6 +76,10 @@ func shouldDeleteDockerRegistry(h testHelper, name, deploymentName string) {
 
 	Expect(deployList.Items).To(HaveLen(1))
 
+	// this suite does not register the Secret controller, which mirrors a cluster where it is
+	// already gone, so the finalizer it would have added has to be put in place by hand
+	h.addFinalizerToSecret(registry.InternalAccessSecretName, registry.ConfigSecretFinalizer)
+
 	// act
 	var dockerRegistry v1alpha1.DockerRegistry
 	Eventually(h.getKubernetesObjectFunc(name, &dockerRegistry)).
@@ -93,5 +98,17 @@ func shouldDeleteDockerRegistry(h testHelper, name, deploymentName string) {
 	Eventually(h.getKubernetesObjectFunc(deploymentName, &appsv1.Deployment{})).
 		WithPolling(time.Second * 2).
 		WithTimeout(time.Second * 10).
+		Should(BeTrue())
+
+	Eventually(h.kubernetesObjectIsGoneFunc(registry.InternalAccessSecretName, &corev1.Secret{})).
+		WithPolling(time.Second).
+		WithTimeout(time.Second * 30).
+		Should(BeTrue())
+
+	h.releasePVCProtectionFinalizer(registryPVCName)
+
+	Eventually(h.kubernetesObjectIsGoneFunc(name, &v1alpha1.DockerRegistry{})).
+		WithPolling(time.Second).
+		WithTimeout(time.Second * 30).
 		Should(BeTrue())
 }

--- a/components/operator/controllers/testhelper_test.go
+++ b/components/operator/controllers/testhelper_test.go
@@ -12,9 +12,16 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	pvcProtectionFinalizer = "kubernetes.io/pvc-protection"
+	registryPVCName        = "dockerregistry"
 )
 
 type conditionMatcher struct {
@@ -123,6 +130,52 @@ func (h *testHelper) getKubernetesObjectFunc(objectName string, obj client.Objec
 	return func() (bool, error) {
 		return h.getKubernetesObject(objectName, obj)
 	}
+}
+
+func (h *testHelper) kubernetesObjectIsGoneFunc(objectName string, obj client.Object) func() (bool, error) {
+	return func() (bool, error) {
+		found, err := h.getKubernetesObject(objectName, obj)
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return !found, nil
+	}
+}
+
+// releasePVCProtectionFinalizer stands in for the kube-controller-manager, which envtest does
+// not run. The API server adds kubernetes.io/pvc-protection on creation and nothing here would
+// ever release it, so the chart uninstall could never finish.
+func (h *testHelper) releasePVCProtectionFinalizer(pvcName string) {
+	By(fmt.Sprintf("Releasing pvc-protection finalizer: %s", pvcName))
+	var pvc corev1.PersistentVolumeClaim
+	Eventually(func() (bool, error) {
+		found, err := h.getKubernetesObject(pvcName, &pvc)
+		if err != nil {
+			return false, err
+		}
+		return found && !pvc.GetDeletionTimestamp().IsZero(), nil
+	}).
+		WithPolling(time.Second).
+		WithTimeout(time.Second * 30).
+		Should(BeTrue())
+
+	Expect(controllerutil.RemoveFinalizer(&pvc, pvcProtectionFinalizer)).To(BeTrue())
+	Expect(k8sClient.Update(h.ctx, &pvc)).To(Succeed())
+}
+
+func (h *testHelper) addFinalizerToSecret(secretName, finalizer string) {
+	By(fmt.Sprintf("Adding finalizer %s to secret: %s", finalizer, secretName))
+	var secret corev1.Secret
+	Eventually(h.getKubernetesObjectFunc(secretName, &secret)).
+		WithPolling(time.Second * 2).
+		WithTimeout(time.Second * 10).
+		Should(BeTrue())
+
+	controllerutil.AddFinalizer(&secret, finalizer)
+	Expect(k8sClient.Update(h.ctx, &secret)).To(Succeed())
 }
 
 func (h *testHelper) getKubernetesObject(objectName string, obj client.Object) (bool, error) {

--- a/components/operator/internal/controllers/kubernetes/secret_service.go
+++ b/components/operator/internal/controllers/kubernetes/secret_service.go
@@ -12,12 +12,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kyma-project/docker-registry/components/operator/internal/registry"
 	"github.com/kyma-project/docker-registry/components/operator/internal/resource"
 )
 
 const (
 	FunctionManagedByLabel         = "dockerregistry.kyma-project.io/managed-by"
-	cfgSecretFinalizerName         = "dockerregistry.kyma-project.io/finalizer-registry-config"
+	cfgSecretFinalizerName         = registry.ConfigSecretFinalizer
 	FunctionResourceLabelUserValue = "user"
 )
 

--- a/components/operator/internal/registry/secret.go
+++ b/components/operator/internal/registry/secret.go
@@ -6,6 +6,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -15,7 +16,39 @@ const (
 	LabelConfigVal           = "credentials"
 	DeploymentName           = "dockerregistry"
 	HttpEnvKey               = "REGISTRY_HTTP_SECRET"
+	ConfigSecretFinalizer    = "dockerregistry.kyma-project.io/finalizer-registry-config"
 )
+
+// ReleaseConfigSecretFinalizers removes ConfigSecretFinalizer from every terminating config
+// Secret in the given namespace. The Secret controller that normally owns this finalizer is
+// deployed into that same namespace, so it can be torn down before the Secrets it guards are
+// finalized. Nothing would then be left to release them and the namespace could never finish
+// terminating, which also blocks any later reinstallation of the module.
+func ReleaseConfigSecretFinalizers(ctx context.Context, c client.Client, namespace string) error {
+	var secrets corev1.SecretList
+	err := c.List(ctx, &secrets,
+		client.InNamespace(namespace),
+		client.MatchingLabels{LabelConfigKey: LabelConfigVal},
+	)
+	if err != nil {
+		return err
+	}
+
+	for i := range secrets.Items {
+		secret := &secrets.Items[i]
+		if secret.GetDeletionTimestamp().IsZero() {
+			continue
+		}
+		if !controllerutil.RemoveFinalizer(secret, ConfigSecretFinalizer) {
+			continue
+		}
+		if err := c.Update(ctx, secret); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 
 func GetDockerRegistryInternalRegistrySecret(ctx context.Context, c client.Client, namespace string) (*corev1.Secret, error) {
 	secret := corev1.Secret{}

--- a/components/operator/internal/registry/secret_test.go
+++ b/components/operator/internal/registry/secret_test.go
@@ -1,0 +1,103 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const testBaseNamespace = "docker-registry"
+
+func TestReleaseConfigSecretFinalizers(t *testing.T) {
+	testCases := map[string]struct {
+		secret          *corev1.Secret
+		terminating     bool
+		expectDeleted   bool
+		expectFinalizer bool
+	}{
+		"terminating internal config secret is released": {
+			secret:        fixFinalizedSecret(InternalAccessSecretName, testBaseNamespace, true),
+			terminating:   true,
+			expectDeleted: true,
+		},
+		"terminating external config secret is released": {
+			secret:        fixFinalizedSecret(ExternalAccessSecretName, testBaseNamespace, true),
+			terminating:   true,
+			expectDeleted: true,
+		},
+		"config secret that is not terminating keeps its finalizer": {
+			secret:          fixFinalizedSecret(InternalAccessSecretName, testBaseNamespace, true),
+			terminating:     false,
+			expectFinalizer: true,
+		},
+		"secret without the config label is left alone": {
+			secret:          fixFinalizedSecret("unrelated-secret", testBaseNamespace, false),
+			terminating:     true,
+			expectFinalizer: true,
+		},
+		"config secret in another namespace is left alone": {
+			secret:          fixFinalizedSecret(InternalAccessSecretName, "other-namespace", true),
+			terminating:     true,
+			expectFinalizer: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			//GIVEN
+			c := fake.NewClientBuilder().WithObjects(testCase.secret).Build()
+			if testCase.terminating {
+				require.NoError(t, c.Delete(context.TODO(), testCase.secret))
+			}
+
+			//WHEN
+			err := ReleaseConfigSecretFinalizers(context.TODO(), c, testBaseNamespace)
+
+			//THEN
+			require.NoError(t, err)
+
+			var actual corev1.Secret
+			getErr := c.Get(context.TODO(), client.ObjectKeyFromObject(testCase.secret), &actual)
+			if testCase.expectDeleted {
+				require.True(t, apierrors.IsNotFound(getErr),
+					"secret should be gone once the finalizer is released, got %v", getErr)
+				return
+			}
+
+			require.NoError(t, getErr)
+			if testCase.expectFinalizer {
+				require.Contains(t, actual.GetFinalizers(), ConfigSecretFinalizer)
+			} else {
+				require.NotContains(t, actual.GetFinalizers(), ConfigSecretFinalizer)
+			}
+		})
+	}
+}
+
+func TestReleaseConfigSecretFinalizersWithoutSecrets(t *testing.T) {
+	c := fake.NewClientBuilder().Build()
+
+	require.NoError(t, ReleaseConfigSecretFinalizers(context.TODO(), c, testBaseNamespace))
+}
+
+func fixFinalizedSecret(name, namespace string, configLabel bool) *corev1.Secret {
+	labels := map[string]string{}
+	if configLabel {
+		labels[LabelConfigKey] = LabelConfigVal
+	}
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  namespace,
+			Labels:     labels,
+			Finalizers: []string{ConfigSecretFinalizer},
+		},
+	}
+}

--- a/components/operator/internal/state/delete.go
+++ b/components/operator/internal/state/delete.go
@@ -62,6 +62,9 @@ func deleteResourcesWithFilter(ctx context.Context, r *reconciler, s *systemStat
 		return uninstallResourcesError(r, s, err)
 	}
 	if !done {
+		if err := registry.ReleaseConfigSecretFinalizers(ctx, r.client, s.instance.GetNamespace()); err != nil {
+			return uninstallResourcesError(r, s, err)
+		}
 		return awaitingSecretsRemoval(s)
 	}
 
@@ -96,6 +99,6 @@ func awaitingSecretsRemoval(s *systemState) (stateFn, *ctrl.Result, error) {
 		"Deleting module resources",
 	)
 
-	// wait one sec until ctrl-mngr remove finalizers from secrets
+	// wait one sec until the API server drops the resources whose deletion was just requested
 	return requeueAfter(time.Second)
 }

--- a/components/operator/internal/state/delete_test.go
+++ b/components/operator/internal/state/delete_test.go
@@ -2,16 +2,21 @@ package state
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/kyma-project/docker-registry/components/operator/api/v1alpha1"
+	"github.com/kyma-project/docker-registry/components/operator/internal/registry"
 	"github.com/kyma-project/manager-toolkit/installation/chart"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -118,4 +123,71 @@ func Test_sFnDeleteResources(t *testing.T) {
 			"DockerRegistry module deleted",
 		)
 	})
+
+	t.Run("config secret finalizer is released while awaiting uninstall", func(t *testing.T) {
+		namespace := testDeletingDockerRegistry.GetNamespace()
+		configSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       registry.InternalAccessSecretName,
+				Namespace:  namespace,
+				Labels:     map[string]string{registry.LabelConfigKey: registry.LabelConfigVal},
+				Finalizers: []string{registry.ConfigSecretFinalizer},
+			},
+		}
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithObjects(&ns, configSecret).
+			Build()
+
+		s := &systemState{
+			instance: *testDeletingDockerRegistry.DeepCopy(),
+			chartConfig: &chart.Config{
+				Ctx:   context.TODO(),
+				Log:   zap.NewNop().Sugar(),
+				Cache: fixManifestCache(fixConfigSecretManifest(namespace)),
+				CacheKey: types.NamespacedName{
+					Name:      testDeletingDockerRegistry.GetName(),
+					Namespace: namespace,
+				},
+				Cluster: chart.Cluster{Client: c},
+			},
+		}
+		r := &reconciler{
+			log: zap.NewNop().Sugar(),
+			k8s: k8s{client: c},
+		}
+
+		next, result, err := sFnSafeDeletionState(context.TODO(), r, s)
+		require.Nil(t, err)
+		require.Nil(t, next)
+		require.NotNil(t, result)
+		require.Equal(t, time.Second, result.RequeueAfter)
+
+		// the Secret controller is not running here, so the state machine has to release the
+		// finalizer itself, otherwise the namespace could never finish terminating
+		getErr := c.Get(context.TODO(), client.ObjectKeyFromObject(configSecret), &corev1.Secret{})
+		require.True(t, apierrors.IsNotFound(getErr),
+			"config secret should be gone once the finalizer is released, got %v", getErr)
+
+		status := s.instance.Status
+		require.Equal(t, v1alpha1.StateDeleting, status.State)
+		requireContainsCondition(t, status,
+			v1alpha1.ConditionTypeDeleted,
+			metav1.ConditionTrue,
+			v1alpha1.ConditionReasonDeletion,
+			"Deleting module resources",
+		)
+	})
+}
+
+func fixConfigSecretManifest(namespace string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Secret
+metadata:
+  name: %s
+  namespace: %s
+  labels:
+    %s: %s
+`, registry.InternalAccessSecretName, namespace, registry.LabelConfigKey, registry.LabelConfigVal)
 }


### PR DESCRIPTION
The config Secret in the module namespace carries a finalizer that only the Secret controller removes, and that controller is deployed into the very namespace the finalizer blocks. When the namespace is torn down, the operator can go away before the Secret is finalized, leaving nothing able to release it. The namespace then stays Terminating forever and the module can never be reinstalled, since nothing can be created in a terminating namespace.

Release the finalizer from the deletion state machine instead of relying on the Secret controller still being alive. Cleanup of the propagated copies in other namespaces is unaffected: the uninstall post-action already sweeps them.

Covers this with a unit test for the release helper, a state-machine test for the uninstall path, and an envtest that reproduces the incident end to end by deleting the CR while no Secret controller is registered. The envtest also had to stand in for the kube-controller-manager on the PVC protection finalizer, which otherwise stalls every uninstall in envtest and was hiding the fact that module deletion never completed there.